### PR TITLE
Update Alert Model

### DIFF
--- a/stream/models.py
+++ b/stream/models.py
@@ -39,20 +39,17 @@ class Alert(models.Model):
     topic = models.ForeignKey(Topic, on_delete=models.PROTECT)
     events = models.ManyToManyField(Event)
     identifier = models.CharField(max_length=200)
-    # We need a way to pass in the timestamps.
-    # If others pass this through the raw or parsed message,
-    # I (Troy) could just shove ours in there as well, and delete the following line
+    # Pass timestamps in as a metadata dict. Maybe other brokers do this differently?
     metadata = models.JSONField(default=dict)
+    # assuming timestamp is currently being used for survey's publish timestamp
     timestamp = models.DateTimeField(null=True, blank=True)
-    # assuming timestamp is currently being used for survey_publish_timestamp
-    # survey_publish_timestamp = models.DateTimeField(null=True, blank=True)
     broker_ingest_timestamp = models.DateTimeField(null=True, blank=True)
     broker_publish_timestamp = models.DateTimeField(null=True, blank=True)
-    desc_ingest_timestamp = models.DateTimeField(null=True, blank=True)
     coordinates = gis_models.PointField(null=True, blank=True)
     parsed_message = models.JSONField(default=dict)
     raw_message = models.JSONField(default=dict)
     parsed = models.BooleanField(default=False)
+    # created is the DESC ingestion timestamp, automatically added on creation
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/stream/models.py
+++ b/stream/models.py
@@ -39,7 +39,16 @@ class Alert(models.Model):
     topic = models.ForeignKey(Topic, on_delete=models.PROTECT)
     events = models.ManyToManyField(Event)
     identifier = models.CharField(max_length=200)
+    # We need a way to pass in the timestamps.
+    # If others pass this through the raw or parsed message,
+    # I (Troy) could just shove ours in there as well, and delete the following line
+    metadata = models.JSONField(default=dict)
     timestamp = models.DateTimeField(null=True, blank=True)
+    # assuming timestamp is currently being used for survey_publish_timestamp
+    # survey_publish_timestamp = models.DateTimeField(null=True, blank=True)
+    broker_ingest_timestamp = models.DateTimeField(null=True, blank=True)
+    broker_publish_timestamp = models.DateTimeField(null=True, blank=True)
+    desc_ingest_timestamp = models.DateTimeField(null=True, blank=True)
     coordinates = gis_models.PointField(null=True, blank=True)
     parsed_message = models.JSONField(default=dict)
     raw_message = models.JSONField(default=dict)


### PR DESCRIPTION
So far, I've added a few spots for timestamps, and a spot for me to pass in metadata (containing our timestamps... not sure how other brokers will want to handle them).

We may want to simply create the `ElasticcAlert` model that @AlexGKim started.

[ELAsTiCC schema](https://docs.google.com/presentation/d/1FwOdELG-XgdNtySeIjF62bDRVU5EsCToi2Svo_kXA50/edit#slide=id.ge52201f94a_0_6), for reference.

I have started a [mapping between an `stream.models.Alert` and the ELAsTiCC schema](https://tom-pittgoogle.readthedocs.io/en/u-tjr-tom_desc/map_alert_to_elasticc.html).