### PR TITLE
Add librdkafka-dev install to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY requirements.txt .
 RUN apt-get update &&\
    apt-get install -y gdal-bin
 
+RUN apt-get update &&\
+    apt-get install -y librdkafka-dev
+
 RUN pip install \
 	--no-cache \
 	--disable-pip-version-check \


### PR DESCRIPTION
Related to #5.

Once I added this install I was able to successfully run `docker-compose` from #5.