### PR TITLE
Initial queries for completeness and efficiency

### DIFF
--- a/README_kostya.md
+++ b/README_kostya.md
@@ -1,0 +1,24 @@
+# Completeness confusion matrix for alerts
+
+```sh
+python3 sql_query_conf_matrices_alerts.py
+python3 plot_conf_matrices.py
+```
+
+# Completeness confusion matrix for objects
+
+It overwrites previous files
+
+```sh
+python3 sql_query_conf_matrices_objects.py
+python3 plot_conf_matrices.py
+```
+
+# Classification efficiency
+
+Number of true positives returned as a last classification by a broker to a total number of objects of this class
+
+```sh
+python3 sql_query_conf_matrices_objects.py
+python3 broker_effiecency.py
+```

--- a/broker_effiecency.py
+++ b/broker_effiecency.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+
+def efficiency(true_counts, matrix):
+    row = matrix.iloc[0]
+    name = f'{row["broker_name"]} {row["classifier_name"]}'
+    for i in true_counts.index:
+        try:
+            pred_count = matrix.loc[(i, i)]['n']
+        except KeyError:
+            pred_count = 0
+        print(name, i, pred_count / true_counts.loc[i]['n'])
+
+
+def main():
+    matrices = pd.read_csv('conf_matrices.csv', index_col=['true_class', 'pred_class'])
+                         # usecols=['true_class', 'pred_class', 'n', 'classifier'], dtype=int)
+    true_counts = pd.read_csv('classes.csv', index_col='true_class', dtype=int)
+    for _, matrix in matrices.groupby('classifier_index'):
+        efficiency(true_counts, matrix)
+
+
+if __name__ == '__main__':
+    main()

--- a/plot_conf_matrices.py
+++ b/plot_conf_matrices.py
@@ -1,0 +1,29 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+from sklearn.metrics import ConfusionMatrixDisplay
+
+
+def plot_matrix(classifier_id, matrix):
+    plt.figure(figsize=(15, 15))
+    row = matrix.iloc[0]
+    name = f'{row["broker_name"]} {row["classifier_name"]}'
+    cmd = ConfusionMatrixDisplay.from_predictions(
+        y_true=matrix['true_class'],
+        y_pred=matrix['pred_class'],
+        normalize='true',
+        ax=plt.gca(),
+    )
+    cmd.ax_.get_images()[0].set_clim(0, 1)
+    plt.title(name)
+    plt.savefig(f'{name}.pdf')
+    plt.close()
+
+
+def main():
+    matrices = pd.read_csv('conf_matrices.csv')
+    for classifier_id, matrix in matrices.groupby('classifier_index'):
+        plot_matrix(classifier_id, matrix)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ hop-client==0.5.0
 avro==1.10.2
 fastavro
 kafka-python
+scikit-learn
+matplotlib

--- a/sql_query_conf_matrices_alerts.py
+++ b/sql_query_conf_matrices_alerts.py
@@ -1,0 +1,418 @@
+import sys
+import os
+import json
+from pprint import pprint
+
+import pandas as pd
+import requests
+
+def main():
+    # Put in your TOM username and password here.  What I have here
+    # reads the password from a private directory, so this code will not
+    # work as is for you.  You just need to set the username and
+    # password variables for use in the rqs.post call below.
+    
+    url = "https://desc-tom.lbl.gov"
+    username = "kostya"
+
+    # First, log in.  Because of Django's prevention against cross-site
+    # scripting attacks, there is some dancing about you have to do in
+    # order to make sure it always gets the right "csrftoken" header.
+
+    rqs = requests.session()
+    rqs.get( f'{url}/accounts/login/' )
+    res = rqs.post( f'{url}/accounts/login/',
+                    data={ "username": username,
+                           "password": os.getenv("DESC_TOM_PASSWORD"),
+                           "csrfmiddlewaretoken": rqs.cookies['csrftoken'] } )
+    if res.status_code != 200:
+        raise RuntimeError( f"Failed to log in; http status: {res.status_code}" )
+    if 'Please enter a correct' in res.text:
+        # This is a very cheesy attempt at checking if the login failed.
+        # I haven't found clean documentation on how to log into a django site
+        # from an app like this using standard authentication stuff.  So, for
+        # now, I'm counting on the HTML that happened to come back when
+        # I ran it with a failed login one time.  One of these days I'll actually
+        # figure out how Django auth works and make a version of /accounts/login/
+        # designed for use in API scripts like this one, rather than desgined
+        # for interactive users.
+        raise RuntimeError( "Failed to log in.  I think.  Put in a debug break and look at res.text" )
+    rqs.headers.update( { 'X-CSRFToken': rqs.cookies['csrftoken'] } )
+
+    # Next, send your query, passing the csrfheader with each request.
+    # (The rqs.headers.update call above makes that happen if you just
+    # keep using the rqs object.)
+    #
+    # You send the query as a json-encoded dictionary with two fields:
+    #   'query' : the SQL query, with %(name)s for things that should
+    #                be substituted.  (This is standard psycopg2.)
+    #   'subdict' : a dictionary of substitutions for %(name)s things in your query
+    #
+    # The backend is to this web API call is readonly, so you can't
+    # bobby tables this.  However, this does give you the freedom to
+    # read anything from the tables if you know the schema.
+    #
+    # At some point in the near future, elasticc truth tables will be restricted
+    # to elasticc admins.
+    #
+    # (Some relevant schema are at the bottom.)
+    
+    # Note that I have to double-quote the column name beacuse otherwise
+    #  Postgres converts things to lc for some reason or another.
+    query = '''
+        SELECT
+        best_classification."classId" AS pred_class,
+        elasticc_classificationmap."classId" AS true_class,
+        elasticc_brokerclassifier."dbClassifierIndex" AS classifier_index,
+        elasticc_brokerclassifier."brokerName" AS broker_name,
+        elasticc_brokerclassifier."classifierName" AS classifier_name,
+        count(*) AS n
+            FROM elasticc_diaobject
+            INNER JOIN elasticc_diaobjecttruth
+                ON (elasticc_diaobject."diaObjectId" = elasticc_diaobjecttruth."diaObject_id")
+            INNER JOIN elasticc_diaalert
+                ON (elasticc_diaobject."diaObjectId" = elasticc_diaalert."diaObject_id")
+            INNER JOIN elasticc_brokermessage
+                ON (elasticc_diaalert."alertId" = elasticc_brokermessage."alertId")
+            INNER JOIN (
+                SELECT DISTINCT ON ("dbMessage_id", "classId")
+                "classId", "probability", "dbMessage_id", "dbClassifier_id"
+                    FROM elasticc_brokerclassification
+                    ORDER BY "dbMessage_id", "classId", "probability" DESC
+            ) best_classification
+                ON (elasticc_brokermessage."dbMessageIndex" = best_classification."dbMessage_id")
+            INNER JOIN elasticc_brokerclassifier
+                ON (best_classification."dbClassifier_id" = elasticc_brokerclassifier."dbClassifierIndex")
+            INNER JOIN elasticc_classificationmap
+                ON (elasticc_diaobjecttruth."gentype" = elasticc_classificationmap."snana_gentype")
+            GROUP BY pred_class, true_class, classifier_index 
+    '''
+    result = rqs.post( f'{url}/db/runsqlquery/',
+                       json={ 'query': query, 'subdict': {} } )
+
+    # Look at the response.  It will be a JSON encoded dict with two fields:
+    #  { 'status': 'ok',
+    #    'rows': [...] }
+    # where rows has the rows returned by the SQL query; each element of the row
+    # is a dict.  There's probably a more efficient way to return this.  I'll
+    # add formatting parameters later -- for instance, it might be nice to be able
+    # to get a serialized pandas DataFrame, which then skips the binary-to-text-to-binary
+    # translation that going through JSON will do.
+
+    if result.status_code != 200:
+        sys.stderr.write( f"ERROR: got status code {result.status_code} ({result.reason})\n" )
+        return
+    data = json.loads( result.text )
+    if ( 'status' not in data ) or ( data['status'] != 'ok' ):
+        sys.stderr.write( f"Got unexpected response:\n{data}\n" )
+        return
+    pprint(data['rows'])
+
+    df = pd.DataFrame.from_records(data['rows'])
+    df.to_csv('conf_matrices.csv', index=False)
+
+
+# ======================================================================
+if __name__ == "__main__":
+    main()
+
+
+# ======================================================================
+# elasticc tables as of 2022-08-05
+#
+# The order of the columns is what happens to be in the database, as a
+# result of the specific history of django databse migrations.  It's not
+# a sane order, alas.  You can find the same schema in the django source
+# code, where the columns are in a more sane order; look at
+# https://github.com/LSSTDESC/tom_desc/blob/main/elasticc/models.py
+
+#             Table "public.elasticc_diaalert"
+#     Column    |  Type  | Collation | Nullable | Default 
+# --------------+--------+-----------+----------+---------
+#  alertId      | bigint |           | not null | 
+#  diaObject_id | bigint |           |          | 
+#  diaSource_id | bigint |           |          | 
+# Indexes:
+#     "elasticc_diaalert_pkey" PRIMARY KEY, btree ("alertId")
+#     "elasticc_diaalert_diaObject_id_809a8089" btree ("diaObject_id")
+#     "elasticc_diaalert_diaSource_id_1f178060" btree ("diaSource_id")
+# Foreign-key constraints:
+#     "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_68c18d04_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_ddb308dc_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                     Table "public.elasticc_diaobject"
+#         Column        |       Type       | Collation | Nullable | Default 
+# ----------------------+------------------+-----------+----------+---------
+#  diaObjectId          | bigint           |           | not null | 
+#  ra                   | double precision |           | not null | 
+#  decl                 | double precision |           | not null | 
+#  mwebv                | double precision |           |          | 
+#  mwebv_err            | double precision |           |          | 
+#  z_final              | double precision |           |          | 
+#  z_final_err          | double precision |           |          | 
+#  hostgal_ellipticity  | double precision |           |          | 
+#  hostgal_sqradius     | double precision |           |          | 
+#  hostgal_zspec        | double precision |           |          | 
+#  hostgal_zspec_err    | double precision |           |          | 
+#  hostgal_zphot_q010   | double precision |           |          | 
+#  hostgal_zphot_q020   | double precision |           |          | 
+#  hostgal_zphot_q030   | double precision |           |          | 
+#  hostgal_zphot_q040   | double precision |           |          | 
+#  hostgal_zphot_q050   | double precision |           |          | 
+#  hostgal_zphot_q060   | double precision |           |          | 
+#  hostgal_zphot_q070   | double precision |           |          | 
+#  hostgal_zphot_q080   | double precision |           |          | 
+#  hostgal_zphot_q090   | double precision |           |          | 
+#  hostgal_zphot_q100   | double precision |           |          | 
+#  hostgal_mag_u        | double precision |           |          | 
+#  hostgal_mag_g        | double precision |           |          | 
+#  hostgal_mag_r        | double precision |           |          | 
+#  hostgal_mag_i        | double precision |           |          | 
+#  hostgal_mag_z        | double precision |           |          | 
+#  hostgal_mag_Y        | double precision |           |          | 
+#  hostgal_ra           | double precision |           |          | 
+#  hostgal_dec          | double precision |           |          | 
+#  hostgal_snsep        | double precision |           |          | 
+#  hostgal_magerr_u     | double precision |           |          | 
+#  hostgal_magerr_g     | double precision |           |          | 
+#  hostgal_magerr_r     | double precision |           |          | 
+#  hostgal_magerr_i     | double precision |           |          | 
+#  hostgal_magerr_z     | double precision |           |          | 
+#  hostgal_magerr_Y     | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_zphot_q090  | double precision |           |          | 
+#  hostgal2_zphot_q100  | double precision |           |          | 
+#  hostgal2_mag_u       | double precision |           |          | 
+#  hostgal2_mag_g       | double precision |           |          | 
+#  hostgal2_mag_r       | double precision |           |          | 
+#  hostgal2_mag_i       | double precision |           |          | 
+#  hostgal2_mag_z       | double precision |           |          | 
+#  hostgal2_mag_Y       | double precision |           |          | 
+#  hostgal2_ra          | double precision |           |          | 
+#  hostgal2_dec         | double precision |           |          | 
+#  hostgal2_snsep       | double precision |           |          | 
+#  hostgal2_magerr_u    | double precision |           |          | 
+#  hostgal2_magerr_g    | double precision |           |          | 
+#  hostgal2_magerr_r    | double precision |           |          | 
+#  hostgal2_magerr_i    | double precision |           |          | 
+#  hostgal2_magerr_z    | double precision |           |          | 
+#  hostgal2_magerr_Y    | double precision |           |          | 
+#  simVersion           | text             |           |          | 
+#  hostgal2_zphot_q000  | double precision |           |          | 
+#  hostgal2_zspec       | double precision |           |          | 
+#  hostgal2_zspec_err   | double precision |           |          | 
+#  hostgal_zphot        | double precision |           |          | 
+#  hostgal_zphot_err    | double precision |           |          | 
+#  hostgal_zphot_p50    | double precision |           |          | 
+#  hostgal_zphot_q000   | double precision |           |          | 
+#  hostgal2_zphot_p50   | double precision |           |          | 
+# Indexes:
+#     "elasticc_diaobject_pkey" PRIMARY KEY, btree ("diaObjectId")
+#     "idx_elasticc_diaobject_q3c" btree (q3c_ang2ipix(ra, decl))
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaforcedsource" CONSTRAINT "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaobjecttruth" CONSTRAINT "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diasource" CONSTRAINT "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                    Table "public.elasticc_diasource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaSourceId       | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  parentDiaSourceId | bigint           |           |          | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  ra                | double precision |           | not null | 
+#  decl              | double precision |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  snr               | double precision |           | not null | 
+#  nobs              | double precision |           |          | 
+#  diaObject_id      | bigint           |           |          | 
+# Indexes:
+#     "elasticc_diasource_pkey" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diasource_diaObject_id_3b88bc59" btree ("diaObject_id")
+#     "elasticc_diasource_midPointTai_5766b47f" btree ("midPointTai")
+#     "idx_elasticc_diasource_q3c" btree (q3c_ang2ipix(ra, decl))
+# Foreign-key constraints:
+#     "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaSource_id_91fa84a3_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                 Table "public.elasticc_diaforcedsource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaForcedSourceId | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  totFlux           | double precision |           | not null | 
+#  totFluxErr        | double precision |           | not null | 
+#  diaObject_id      | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaforcedsource_pkey" PRIMARY KEY, btree ("diaForcedSourceId")
+#     "elasticc_diaforcedsource_diaObject_id_8b1bc498" btree ("diaObject_id")
+#     "elasticc_diaforcedsource_midPointTai_a80b03af" btree ("midPointTai")
+# Foreign-key constraints:
+#     "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaForcedSource_id_783ade34_fk_elasticc_" FOREIGN KEY ("diaForcedSource_id") REFERENCES elasticc_diaforcedsource("diaForcedSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                  Table "public.elasticc_diatruth"
+#     Column    |       Type       | Collation | Nullable | Default 
+# --------------+------------------+-----------+----------+---------
+#  diaSourceId  | bigint           |           | not null | 
+#  diaObjectId  | bigint           |           |          | 
+#  detect       | boolean          |           |          | 
+#  true_gentype | integer          |           |          | 
+#  true_genmag  | double precision |           |          | 
+#  mjd          | double precision |           |          | 
+# Indexes:
+#     "elasticc_diatruth_diaSourceId_648273bb_pk" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diatruth_diaObjectId_7dd96889" btree ("diaObjectId")
+#     "elasticc_diatruth_diaSourceId_648273bb_uniq" UNIQUE CONSTRAINT, btree ("diaSourceId")
+# 
+#                  Table "public.elasticc_diaobjecttruth"
+#        Column       |       Type       | Collation | Nullable | Default 
+# --------------------+------------------+-----------+----------+---------
+#  libid              | integer          |           | not null | 
+#  sim_searcheff_mask | integer          |           | not null | 
+#  gentype            | integer          |           | not null | 
+#  sim_template_index | integer          |           | not null | 
+#  zcmb               | double precision |           | not null | 
+#  zhelio             | double precision |           | not null | 
+#  zcmb_smear         | double precision |           | not null | 
+#  ra                 | double precision |           | not null | 
+#  dec                | double precision |           | not null | 
+#  mwebv              | double precision |           | not null | 
+#  galid              | bigint           |           | not null | 
+#  galzphot           | double precision |           | not null | 
+#  galzphoterr        | double precision |           | not null | 
+#  galsnsep           | double precision |           | not null | 
+#  galsnddlr          | double precision |           | not null | 
+#  rv                 | double precision |           | not null | 
+#  av                 | double precision |           | not null | 
+#  mu                 | double precision |           | not null | 
+#  lensdmu            | double precision |           | not null | 
+#  peakmjd            | double precision |           | not null | 
+#  mjd_detect_first   | double precision |           | not null | 
+#  mjd_detect_last    | double precision |           | not null | 
+#  dtseason_peak      | double precision |           | not null | 
+#  peakmag_u          | double precision |           | not null | 
+#  peakmag_g          | double precision |           | not null | 
+#  peakmag_r          | double precision |           | not null | 
+#  peakmag_i          | double precision |           | not null | 
+#  peakmag_z          | double precision |           | not null | 
+#  peakmag_Y          | double precision |           | not null | 
+#  snrmax             | double precision |           | not null | 
+#  snrmax2            | double precision |           | not null | 
+#  snrmax3            | double precision |           | not null | 
+#  nobs               | integer          |           | not null | 
+#  nobs_saturate      | integer          |           | not null | 
+#  diaObject_id       | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaobjecttruth_pkey" PRIMARY KEY, btree ("diaObject_id")
+#     "elasticc_diaobjecttruth_gentype_480cd308" btree (gentype)
+#     "elasticc_diaobjecttruth_sim_template_index_b33f9ab4" btree (sim_template_index)
+# Foreign-key constraints:
+#     "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                 Table "public.elasticc_classificationmap"
+#     Column     |  Type   | Collation | Nullable |                        Default                         
+# ---------------+---------+-----------+----------+--------------------------------------------------------
+#  id            | integer |           | not null | nextval('elasticc_classificationmap_id_seq'::regclass)
+#  classId       | integer |           | not null | 
+#  snana_gentype | integer |           |          | 
+#  description   | text    |           | not null | 
+# Indexes:
+#     "elasticc_classificationmap_pkey" PRIMARY KEY, btree (id)
+#     "elasticc_classificationmap_classId_27acf0d1" btree ("classId")
+#     "elasticc_classificationmap_snana_gentype_63c19152" btree (snana_gentype)
+# 
+# tom_desc=# \d elasticc_brokermessage
+#                                                      Table "public.elasticc_brokermessage"
+#           Column          |           Type           | Collation | Nullable |                             Default                              
+# --------------------------+--------------------------+-----------+----------+------------------------------------------------------------------
+#  dbMessageIndex           | bigint                   |           | not null | nextval('"elasticc_brokermessage_dbMessageIndex_seq"'::regclass)
+#  streamMessageId          | bigint                   |           |          | 
+#  topicName                | character varying(200)   |           |          | 
+#  alertId                  | bigint                   |           | not null | 
+#  diaSourceId              | bigint                   |           | not null | 
+#  descIngestTimestamp      | timestamp with time zone |           | not null | 
+#  elasticcPublishTimestamp | timestamp with time zone |           |          | 
+#  brokerIngestTimestamp    | timestamp with time zone |           |          | 
+#  modified                 | timestamp with time zone |           | not null | 
+#  msgHdrTimestamp          | timestamp with time zone |           |          | 
+# Indexes:
+#     "elasticc_brokermessage_pkey" PRIMARY KEY, btree ("dbMessageIndex")
+#     "elasticc_br_alertId_b419c9_idx" btree ("alertId")
+#     "elasticc_br_dbMessa_59550d_idx" btree ("dbMessageIndex")
+#     "elasticc_br_diaSour_ca3044_idx" btree ("diaSourceId")
+#     "elasticc_br_topicNa_73f5a4_idx" btree ("topicName", "streamMessageId")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                                    Table "public.elasticc_brokerclassifier"
+#       Column       |           Type           | Collation | Nullable |                                Default                                 
+# -------------------+--------------------------+-----------+----------+------------------------------------------------------------------------
+#  dbClassifierIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassifier_dbClassifierIndex_seq"'::regclass)
+#  brokerName        | character varying(100)   |           | not null | 
+#  brokerVersion     | text                     |           |          | 
+#  classifierName    | character varying(200)   |           | not null | 
+#  classifierParams  | text                     |           |          | 
+#  modified          | timestamp with time zone |           | not null | 
+# Indexes:
+#     "elasticc_brokerclassifier_pkey" PRIMARY KEY, btree ("dbClassifierIndex")
+#     "elasticc_br_brokerN_38d99f_idx" btree ("brokerName", "classifierName")
+#     "elasticc_br_brokerN_86cc1a_idx" btree ("brokerName")
+#     "elasticc_br_brokerN_eb7553_idx" btree ("brokerName", "brokerVersion")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+# 
+#                                                        Table "public.elasticc_brokerclassification"
+#         Column         |           Type           | Collation | Nullable |                                    Default                                     
+# -----------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------------
+#  dbClassificationIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassification_dbClassificationIndex_seq"'::regclass)
+#  classId               | integer                  |           | not null | 
+#  probability           | double precision         |           | not null | 
+#  modified              | timestamp with time zone |           | not null | 
+#  dbClassifier_id       | bigint                   |           |          | 
+#  dbMessage_id          | bigint                   |           |          | 
+# Indexes:
+#     "elasticc_brokerclassification_pkey" PRIMARY KEY, btree ("dbClassificationIndex")
+#     "elasticc_brokerclassification_dbClassifier_id_91d33318" btree ("dbClassifier_id")
+#     "elasticc_brokerclassification_dbMessage_id_b8bd04da" btree ("dbMessage_id")
+# Foreign-key constraints:
+#     "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED

--- a/sql_query_conf_matrices_objects.py
+++ b/sql_query_conf_matrices_objects.py
@@ -1,0 +1,425 @@
+import sys
+import os
+import json
+from pprint import pprint
+
+import pandas as pd
+import requests
+
+def main():
+    # Put in your TOM username and password here.  What I have here
+    # reads the password from a private directory, so this code will not
+    # work as is for you.  You just need to set the username and
+    # password variables for use in the rqs.post call below.
+    
+    url = "https://desc-tom.lbl.gov"
+    username = "kostya"
+
+    # First, log in.  Because of Django's prevention against cross-site
+    # scripting attacks, there is some dancing about you have to do in
+    # order to make sure it always gets the right "csrftoken" header.
+
+    rqs = requests.session()
+    rqs.get( f'{url}/accounts/login/' )
+    res = rqs.post( f'{url}/accounts/login/',
+                    data={ "username": username,
+                           "password": os.getenv("DESC_TOM_PASSWORD"),
+                           "csrfmiddlewaretoken": rqs.cookies['csrftoken'] } )
+    if res.status_code != 200:
+        raise RuntimeError( f"Failed to log in; http status: {res.status_code}" )
+    if 'Please enter a correct' in res.text:
+        # This is a very cheesy attempt at checking if the login failed.
+        # I haven't found clean documentation on how to log into a django site
+        # from an app like this using standard authentication stuff.  So, for
+        # now, I'm counting on the HTML that happened to come back when
+        # I ran it with a failed login one time.  One of these days I'll actually
+        # figure out how Django auth works and make a version of /accounts/login/
+        # designed for use in API scripts like this one, rather than desgined
+        # for interactive users.
+        raise RuntimeError( "Failed to log in.  I think.  Put in a debug break and look at res.text" )
+    rqs.headers.update( { 'X-CSRFToken': rqs.cookies['csrftoken'] } )
+
+    # Next, send your query, passing the csrfheader with each request.
+    # (The rqs.headers.update call above makes that happen if you just
+    # keep using the rqs object.)
+    #
+    # You send the query as a json-encoded dictionary with two fields:
+    #   'query' : the SQL query, with %(name)s for things that should
+    #                be substituted.  (This is standard psycopg2.)
+    #   'subdict' : a dictionary of substitutions for %(name)s things in your query
+    #
+    # The backend is to this web API call is readonly, so you can't
+    # bobby tables this.  However, this does give you the freedom to
+    # read anything from the tables if you know the schema.
+    #
+    # At some point in the near future, elasticc truth tables will be restricted
+    # to elasticc admins.
+    #
+    # (Some relevant schema are at the bottom.)
+    
+    # Note that I have to double-quote the column name beacuse otherwise
+    #  Postgres converts things to lc for some reason or another.
+    query = '''
+        SELECT
+        best_classification."classId" AS pred_class,
+        elasticc_classificationmap."classId" AS true_class,
+        elasticc_brokerclassifier."dbClassifierIndex" AS classifier_index,
+        elasticc_brokerclassifier."brokerName" AS broker_name,
+        elasticc_brokerclassifier."classifierName" AS classifier_name,
+        count(*) AS n
+            FROM elasticc_diaobject
+            INNER JOIN elasticc_diaobjecttruth
+                ON (elasticc_diaobject."diaObjectId" = elasticc_diaobjecttruth."diaObject_id")
+            INNER JOIN (
+                SELECT DISTINCT ON (elasticc_brokerclassification."dbClassifier_id", elasticc_diaalert."diaObject_id")
+                "diaObject_id", "dbMessageIndex", "dbClassifier_id"
+                    FROM elasticc_brokermessage
+                    INNER JOIN elasticc_diaalert
+                        ON (elasticc_brokermessage."alertId" = elasticc_diaalert."alertId")
+                    INNER JOIN elasticc_brokerclassification
+                        ON (elasticc_brokerclassification."dbMessage_id" = elasticc_brokermessage."dbMessageIndex")
+                    ORDER BY elasticc_brokerclassification."dbClassifier_id", elasticc_diaalert."diaObject_id", "elasticcPublishTimestamp" DESC
+            ) last_broker_message
+                ON (elasticc_diaobject."diaObjectId" = last_broker_message."diaObject_id")
+            INNER JOIN (
+                SELECT DISTINCT ON ("dbMessage_id", "classId")
+                "classId", "probability", "dbMessage_id", "dbClassifier_id"
+                    FROM elasticc_brokerclassification
+                    ORDER BY "dbMessage_id", "classId", "probability" DESC
+            ) best_classification
+                ON (last_broker_message."dbMessageIndex" = best_classification."dbMessage_id")
+            INNER JOIN elasticc_brokerclassifier
+                ON (last_broker_message."dbClassifier_id" = elasticc_brokerclassifier."dbClassifierIndex")
+            INNER JOIN elasticc_classificationmap
+                ON (elasticc_diaobjecttruth."gentype" = elasticc_classificationmap."snana_gentype")
+            GROUP BY pred_class, true_class, classifier_index 
+    '''
+    result = rqs.post( f'{url}/db/runsqlquery/',
+                       json={ 'query': query, 'subdict': {} } )
+
+    # Look at the response.  It will be a JSON encoded dict with two fields:
+    #  { 'status': 'ok',
+    #    'rows': [...] }
+    # where rows has the rows returned by the SQL query; each element of the row
+    # is a dict.  There's probably a more efficient way to return this.  I'll
+    # add formatting parameters later -- for instance, it might be nice to be able
+    # to get a serialized pandas DataFrame, which then skips the binary-to-text-to-binary
+    # translation that going through JSON will do.
+
+    if result.status_code != 200:
+        sys.stderr.write( f"ERROR: got status code {result.status_code} ({result.reason})\n" )
+        return
+    data = json.loads( result.text )
+    if ( 'status' not in data ) or ( data['status'] != 'ok' ):
+        sys.stderr.write( f"Got unexpected response:\n{data}\n" )
+        return
+    pprint(data['rows'])
+
+    df = pd.DataFrame.from_records(data['rows'])
+    df.to_csv('conf_matrices.csv', index=False)
+
+
+# ======================================================================
+if __name__ == "__main__":
+    main()
+
+
+# ======================================================================
+# elasticc tables as of 2022-08-05
+#
+# The order of the columns is what happens to be in the database, as a
+# result of the specific history of django databse migrations.  It's not
+# a sane order, alas.  You can find the same schema in the django source
+# code, where the columns are in a more sane order; look at
+# https://github.com/LSSTDESC/tom_desc/blob/main/elasticc/models.py
+
+#             Table "public.elasticc_diaalert"
+#     Column    |  Type  | Collation | Nullable | Default 
+# --------------+--------+-----------+----------+---------
+#  alertId      | bigint |           | not null | 
+#  diaObject_id | bigint |           |          | 
+#  diaSource_id | bigint |           |          | 
+# Indexes:
+#     "elasticc_diaalert_pkey" PRIMARY KEY, btree ("alertId")
+#     "elasticc_diaalert_diaObject_id_809a8089" btree ("diaObject_id")
+#     "elasticc_diaalert_diaSource_id_1f178060" btree ("diaSource_id")
+# Foreign-key constraints:
+#     "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_68c18d04_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_ddb308dc_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                     Table "public.elasticc_diaobject"
+#         Column        |       Type       | Collation | Nullable | Default 
+# ----------------------+------------------+-----------+----------+---------
+#  diaObjectId          | bigint           |           | not null | 
+#  ra                   | double precision |           | not null | 
+#  decl                 | double precision |           | not null | 
+#  mwebv                | double precision |           |          | 
+#  mwebv_err            | double precision |           |          | 
+#  z_final              | double precision |           |          | 
+#  z_final_err          | double precision |           |          | 
+#  hostgal_ellipticity  | double precision |           |          | 
+#  hostgal_sqradius     | double precision |           |          | 
+#  hostgal_zspec        | double precision |           |          | 
+#  hostgal_zspec_err    | double precision |           |          | 
+#  hostgal_zphot_q010   | double precision |           |          | 
+#  hostgal_zphot_q020   | double precision |           |          | 
+#  hostgal_zphot_q030   | double precision |           |          | 
+#  hostgal_zphot_q040   | double precision |           |          | 
+#  hostgal_zphot_q050   | double precision |           |          | 
+#  hostgal_zphot_q060   | double precision |           |          | 
+#  hostgal_zphot_q070   | double precision |           |          | 
+#  hostgal_zphot_q080   | double precision |           |          | 
+#  hostgal_zphot_q090   | double precision |           |          | 
+#  hostgal_zphot_q100   | double precision |           |          | 
+#  hostgal_mag_u        | double precision |           |          | 
+#  hostgal_mag_g        | double precision |           |          | 
+#  hostgal_mag_r        | double precision |           |          | 
+#  hostgal_mag_i        | double precision |           |          | 
+#  hostgal_mag_z        | double precision |           |          | 
+#  hostgal_mag_Y        | double precision |           |          | 
+#  hostgal_ra           | double precision |           |          | 
+#  hostgal_dec          | double precision |           |          | 
+#  hostgal_snsep        | double precision |           |          | 
+#  hostgal_magerr_u     | double precision |           |          | 
+#  hostgal_magerr_g     | double precision |           |          | 
+#  hostgal_magerr_r     | double precision |           |          | 
+#  hostgal_magerr_i     | double precision |           |          | 
+#  hostgal_magerr_z     | double precision |           |          | 
+#  hostgal_magerr_Y     | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_zphot_q090  | double precision |           |          | 
+#  hostgal2_zphot_q100  | double precision |           |          | 
+#  hostgal2_mag_u       | double precision |           |          | 
+#  hostgal2_mag_g       | double precision |           |          | 
+#  hostgal2_mag_r       | double precision |           |          | 
+#  hostgal2_mag_i       | double precision |           |          | 
+#  hostgal2_mag_z       | double precision |           |          | 
+#  hostgal2_mag_Y       | double precision |           |          | 
+#  hostgal2_ra          | double precision |           |          | 
+#  hostgal2_dec         | double precision |           |          | 
+#  hostgal2_snsep       | double precision |           |          | 
+#  hostgal2_magerr_u    | double precision |           |          | 
+#  hostgal2_magerr_g    | double precision |           |          | 
+#  hostgal2_magerr_r    | double precision |           |          | 
+#  hostgal2_magerr_i    | double precision |           |          | 
+#  hostgal2_magerr_z    | double precision |           |          | 
+#  hostgal2_magerr_Y    | double precision |           |          | 
+#  simVersion           | text             |           |          | 
+#  hostgal2_zphot_q000  | double precision |           |          | 
+#  hostgal2_zspec       | double precision |           |          | 
+#  hostgal2_zspec_err   | double precision |           |          | 
+#  hostgal_zphot        | double precision |           |          | 
+#  hostgal_zphot_err    | double precision |           |          | 
+#  hostgal_zphot_p50    | double precision |           |          | 
+#  hostgal_zphot_q000   | double precision |           |          | 
+#  hostgal2_zphot_p50   | double precision |           |          | 
+# Indexes:
+#     "elasticc_diaobject_pkey" PRIMARY KEY, btree ("diaObjectId")
+#     "idx_elasticc_diaobject_q3c" btree (q3c_ang2ipix(ra, decl))
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaforcedsource" CONSTRAINT "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaobjecttruth" CONSTRAINT "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diasource" CONSTRAINT "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                    Table "public.elasticc_diasource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaSourceId       | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  parentDiaSourceId | bigint           |           |          | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  ra                | double precision |           | not null | 
+#  decl              | double precision |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  snr               | double precision |           | not null | 
+#  nobs              | double precision |           |          | 
+#  diaObject_id      | bigint           |           |          | 
+# Indexes:
+#     "elasticc_diasource_pkey" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diasource_diaObject_id_3b88bc59" btree ("diaObject_id")
+#     "elasticc_diasource_midPointTai_5766b47f" btree ("midPointTai")
+#     "idx_elasticc_diasource_q3c" btree (q3c_ang2ipix(ra, decl))
+# Foreign-key constraints:
+#     "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaSource_id_91fa84a3_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                 Table "public.elasticc_diaforcedsource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaForcedSourceId | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  totFlux           | double precision |           | not null | 
+#  totFluxErr        | double precision |           | not null | 
+#  diaObject_id      | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaforcedsource_pkey" PRIMARY KEY, btree ("diaForcedSourceId")
+#     "elasticc_diaforcedsource_diaObject_id_8b1bc498" btree ("diaObject_id")
+#     "elasticc_diaforcedsource_midPointTai_a80b03af" btree ("midPointTai")
+# Foreign-key constraints:
+#     "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaForcedSource_id_783ade34_fk_elasticc_" FOREIGN KEY ("diaForcedSource_id") REFERENCES elasticc_diaforcedsource("diaForcedSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                  Table "public.elasticc_diatruth"
+#     Column    |       Type       | Collation | Nullable | Default 
+# --------------+------------------+-----------+----------+---------
+#  diaSourceId  | bigint           |           | not null | 
+#  diaObjectId  | bigint           |           |          | 
+#  detect       | boolean          |           |          | 
+#  true_gentype | integer          |           |          | 
+#  true_genmag  | double precision |           |          | 
+#  mjd          | double precision |           |          | 
+# Indexes:
+#     "elasticc_diatruth_diaSourceId_648273bb_pk" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diatruth_diaObjectId_7dd96889" btree ("diaObjectId")
+#     "elasticc_diatruth_diaSourceId_648273bb_uniq" UNIQUE CONSTRAINT, btree ("diaSourceId")
+# 
+#                  Table "public.elasticc_diaobjecttruth"
+#        Column       |       Type       | Collation | Nullable | Default 
+# --------------------+------------------+-----------+----------+---------
+#  libid              | integer          |           | not null | 
+#  sim_searcheff_mask | integer          |           | not null | 
+#  gentype            | integer          |           | not null | 
+#  sim_template_index | integer          |           | not null | 
+#  zcmb               | double precision |           | not null | 
+#  zhelio             | double precision |           | not null | 
+#  zcmb_smear         | double precision |           | not null | 
+#  ra                 | double precision |           | not null | 
+#  dec                | double precision |           | not null | 
+#  mwebv              | double precision |           | not null | 
+#  galid              | bigint           |           | not null | 
+#  galzphot           | double precision |           | not null | 
+#  galzphoterr        | double precision |           | not null | 
+#  galsnsep           | double precision |           | not null | 
+#  galsnddlr          | double precision |           | not null | 
+#  rv                 | double precision |           | not null | 
+#  av                 | double precision |           | not null | 
+#  mu                 | double precision |           | not null | 
+#  lensdmu            | double precision |           | not null | 
+#  peakmjd            | double precision |           | not null | 
+#  mjd_detect_first   | double precision |           | not null | 
+#  mjd_detect_last    | double precision |           | not null | 
+#  dtseason_peak      | double precision |           | not null | 
+#  peakmag_u          | double precision |           | not null | 
+#  peakmag_g          | double precision |           | not null | 
+#  peakmag_r          | double precision |           | not null | 
+#  peakmag_i          | double precision |           | not null | 
+#  peakmag_z          | double precision |           | not null | 
+#  peakmag_Y          | double precision |           | not null | 
+#  snrmax             | double precision |           | not null | 
+#  snrmax2            | double precision |           | not null | 
+#  snrmax3            | double precision |           | not null | 
+#  nobs               | integer          |           | not null | 
+#  nobs_saturate      | integer          |           | not null | 
+#  diaObject_id       | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaobjecttruth_pkey" PRIMARY KEY, btree ("diaObject_id")
+#     "elasticc_diaobjecttruth_gentype_480cd308" btree (gentype)
+#     "elasticc_diaobjecttruth_sim_template_index_b33f9ab4" btree (sim_template_index)
+# Foreign-key constraints:
+#     "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                 Table "public.elasticc_classificationmap"
+#     Column     |  Type   | Collation | Nullable |                        Default                         
+# ---------------+---------+-----------+----------+--------------------------------------------------------
+#  id            | integer |           | not null | nextval('elasticc_classificationmap_id_seq'::regclass)
+#  classId       | integer |           | not null | 
+#  snana_gentype | integer |           |          | 
+#  description   | text    |           | not null | 
+# Indexes:
+#     "elasticc_classificationmap_pkey" PRIMARY KEY, btree (id)
+#     "elasticc_classificationmap_classId_27acf0d1" btree ("classId")
+#     "elasticc_classificationmap_snana_gentype_63c19152" btree (snana_gentype)
+# 
+# tom_desc=# \d elasticc_brokermessage
+#                                                      Table "public.elasticc_brokermessage"
+#           Column          |           Type           | Collation | Nullable |                             Default                              
+# --------------------------+--------------------------+-----------+----------+------------------------------------------------------------------
+#  dbMessageIndex           | bigint                   |           | not null | nextval('"elasticc_brokermessage_dbMessageIndex_seq"'::regclass)
+#  streamMessageId          | bigint                   |           |          | 
+#  topicName                | character varying(200)   |           |          | 
+#  alertId                  | bigint                   |           | not null | 
+#  diaSourceId              | bigint                   |           | not null | 
+#  descIngestTimestamp      | timestamp with time zone |           | not null | 
+#  elasticcPublishTimestamp | timestamp with time zone |           |          | 
+#  brokerIngestTimestamp    | timestamp with time zone |           |          | 
+#  modified                 | timestamp with time zone |           | not null | 
+#  msgHdrTimestamp          | timestamp with time zone |           |          | 
+# Indexes:
+#     "elasticc_brokermessage_pkey" PRIMARY KEY, btree ("dbMessageIndex")
+#     "elasticc_br_alertId_b419c9_idx" btree ("alertId")
+#     "elasticc_br_dbMessa_59550d_idx" btree ("dbMessageIndex")
+#     "elasticc_br_diaSour_ca3044_idx" btree ("diaSourceId")
+#     "elasticc_br_topicNa_73f5a4_idx" btree ("topicName", "streamMessageId")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                                    Table "public.elasticc_brokerclassifier"
+#       Column       |           Type           | Collation | Nullable |                                Default                                 
+# -------------------+--------------------------+-----------+----------+------------------------------------------------------------------------
+#  dbClassifierIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassifier_dbClassifierIndex_seq"'::regclass)
+#  brokerName        | character varying(100)   |           | not null | 
+#  brokerVersion     | text                     |           |          | 
+#  classifierName    | character varying(200)   |           | not null | 
+#  classifierParams  | text                     |           |          | 
+#  modified          | timestamp with time zone |           | not null | 
+# Indexes:
+#     "elasticc_brokerclassifier_pkey" PRIMARY KEY, btree ("dbClassifierIndex")
+#     "elasticc_br_brokerN_38d99f_idx" btree ("brokerName", "classifierName")
+#     "elasticc_br_brokerN_86cc1a_idx" btree ("brokerName")
+#     "elasticc_br_brokerN_eb7553_idx" btree ("brokerName", "brokerVersion")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+# 
+#                                                        Table "public.elasticc_brokerclassification"
+#         Column         |           Type           | Collation | Nullable |                                    Default                                     
+# -----------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------------
+#  dbClassificationIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassification_dbClassificationIndex_seq"'::regclass)
+#  classId               | integer                  |           | not null | 
+#  probability           | double precision         |           | not null | 
+#  modified              | timestamp with time zone |           | not null | 
+#  dbClassifier_id       | bigint                   |           |          | 
+#  dbMessage_id          | bigint                   |           |          | 
+# Indexes:
+#     "elasticc_brokerclassification_pkey" PRIMARY KEY, btree ("dbClassificationIndex")
+#     "elasticc_brokerclassification_dbClassifier_id_91d33318" btree ("dbClassifier_id")
+#     "elasticc_brokerclassification_dbMessage_id_b8bd04da" btree ("dbMessage_id")
+# Foreign-key constraints:
+#     "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED

--- a/sql_query_count_object_classes.py
+++ b/sql_query_count_object_classes.py
@@ -1,0 +1,401 @@
+import sys
+import os
+import json
+from pprint import pprint
+
+import pandas as pd
+import requests
+
+def main():
+    # Put in your TOM username and password here.  What I have here
+    # reads the password from a private directory, so this code will not
+    # work as is for you.  You just need to set the username and
+    # password variables for use in the rqs.post call below.
+    
+    url = "https://desc-tom.lbl.gov"
+    username = "kostya"
+
+    # First, log in.  Because of Django's prevention against cross-site
+    # scripting attacks, there is some dancing about you have to do in
+    # order to make sure it always gets the right "csrftoken" header.
+
+    rqs = requests.session()
+    rqs.get( f'{url}/accounts/login/' )
+    res = rqs.post( f'{url}/accounts/login/',
+                    data={ "username": username,
+                           "password": os.getenv("DESC_TOM_PASSWORD"),
+                           "csrfmiddlewaretoken": rqs.cookies['csrftoken'] } )
+    if res.status_code != 200:
+        raise RuntimeError( f"Failed to log in; http status: {res.status_code}" )
+    if 'Please enter a correct' in res.text:
+        # This is a very cheesy attempt at checking if the login failed.
+        # I haven't found clean documentation on how to log into a django site
+        # from an app like this using standard authentication stuff.  So, for
+        # now, I'm counting on the HTML that happened to come back when
+        # I ran it with a failed login one time.  One of these days I'll actually
+        # figure out how Django auth works and make a version of /accounts/login/
+        # designed for use in API scripts like this one, rather than desgined
+        # for interactive users.
+        raise RuntimeError( "Failed to log in.  I think.  Put in a debug break and look at res.text" )
+    rqs.headers.update( { 'X-CSRFToken': rqs.cookies['csrftoken'] } )
+
+    # Next, send your query, passing the csrfheader with each request.
+    # (The rqs.headers.update call above makes that happen if you just
+    # keep using the rqs object.)
+    #
+    # You send the query as a json-encoded dictionary with two fields:
+    #   'query' : the SQL query, with %(name)s for things that should
+    #                be substituted.  (This is standard psycopg2.)
+    #   'subdict' : a dictionary of substitutions for %(name)s things in your query
+    #
+    # The backend is to this web API call is readonly, so you can't
+    # bobby tables this.  However, this does give you the freedom to
+    # read anything from the tables if you know the schema.
+    #
+    # At some point in the near future, elasticc truth tables will be restricted
+    # to elasticc admins.
+    #
+    # (Some relevant schema are at the bottom.)
+    
+    # Note that I have to double-quote the column name beacuse otherwise
+    #  Postgres converts things to lc for some reason or another.
+    query = '''
+        SELECT
+        elasticc_classificationmap."classId" AS true_class,
+        count(*) AS n
+            FROM elasticc_diaobject
+            INNER JOIN elasticc_diaobjecttruth
+                ON (elasticc_diaobject."diaObjectId" = elasticc_diaobjecttruth."diaObject_id")
+            INNER JOIN elasticc_classificationmap
+                ON (elasticc_diaobjecttruth."gentype" = elasticc_classificationmap."snana_gentype")
+            GROUP BY true_class
+    '''
+    result = rqs.post( f'{url}/db/runsqlquery/',
+                       json={ 'query': query, 'subdict': {} } )
+
+    # Look at the response.  It will be a JSON encoded dict with two fields:
+    #  { 'status': 'ok',
+    #    'rows': [...] }
+    # where rows has the rows returned by the SQL query; each element of the row
+    # is a dict.  There's probably a more efficient way to return this.  I'll
+    # add formatting parameters later -- for instance, it might be nice to be able
+    # to get a serialized pandas DataFrame, which then skips the binary-to-text-to-binary
+    # translation that going through JSON will do.
+
+    if result.status_code != 200:
+        sys.stderr.write( f"ERROR: got status code {result.status_code} ({result.reason})\n" )
+        return
+    data = json.loads( result.text )
+    if ( 'status' not in data ) or ( data['status'] != 'ok' ):
+        sys.stderr.write( f"Got unexpected response:\n{data}\n" )
+        return
+    pprint(data['rows'])
+
+    df = pd.DataFrame.from_records(data['rows'])
+    df.to_csv('classes.csv', index=False)
+
+
+# ======================================================================
+if __name__ == "__main__":
+    main()
+
+
+# ======================================================================
+# elasticc tables as of 2022-08-05
+#
+# The order of the columns is what happens to be in the database, as a
+# result of the specific history of django databse migrations.  It's not
+# a sane order, alas.  You can find the same schema in the django source
+# code, where the columns are in a more sane order; look at
+# https://github.com/LSSTDESC/tom_desc/blob/main/elasticc/models.py
+
+#             Table "public.elasticc_diaalert"
+#     Column    |  Type  | Collation | Nullable | Default 
+# --------------+--------+-----------+----------+---------
+#  alertId      | bigint |           | not null | 
+#  diaObject_id | bigint |           |          | 
+#  diaSource_id | bigint |           |          | 
+# Indexes:
+#     "elasticc_diaalert_pkey" PRIMARY KEY, btree ("alertId")
+#     "elasticc_diaalert_diaObject_id_809a8089" btree ("diaObject_id")
+#     "elasticc_diaalert_diaSource_id_1f178060" btree ("diaSource_id")
+# Foreign-key constraints:
+#     "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_68c18d04_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaAlert_id_ddb308dc_fk_elasticc_" FOREIGN KEY ("diaAlert_id") REFERENCES elasticc_diaalert("alertId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                     Table "public.elasticc_diaobject"
+#         Column        |       Type       | Collation | Nullable | Default 
+# ----------------------+------------------+-----------+----------+---------
+#  diaObjectId          | bigint           |           | not null | 
+#  ra                   | double precision |           | not null | 
+#  decl                 | double precision |           | not null | 
+#  mwebv                | double precision |           |          | 
+#  mwebv_err            | double precision |           |          | 
+#  z_final              | double precision |           |          | 
+#  z_final_err          | double precision |           |          | 
+#  hostgal_ellipticity  | double precision |           |          | 
+#  hostgal_sqradius     | double precision |           |          | 
+#  hostgal_zspec        | double precision |           |          | 
+#  hostgal_zspec_err    | double precision |           |          | 
+#  hostgal_zphot_q010   | double precision |           |          | 
+#  hostgal_zphot_q020   | double precision |           |          | 
+#  hostgal_zphot_q030   | double precision |           |          | 
+#  hostgal_zphot_q040   | double precision |           |          | 
+#  hostgal_zphot_q050   | double precision |           |          | 
+#  hostgal_zphot_q060   | double precision |           |          | 
+#  hostgal_zphot_q070   | double precision |           |          | 
+#  hostgal_zphot_q080   | double precision |           |          | 
+#  hostgal_zphot_q090   | double precision |           |          | 
+#  hostgal_zphot_q100   | double precision |           |          | 
+#  hostgal_mag_u        | double precision |           |          | 
+#  hostgal_mag_g        | double precision |           |          | 
+#  hostgal_mag_r        | double precision |           |          | 
+#  hostgal_mag_i        | double precision |           |          | 
+#  hostgal_mag_z        | double precision |           |          | 
+#  hostgal_mag_Y        | double precision |           |          | 
+#  hostgal_ra           | double precision |           |          | 
+#  hostgal_dec          | double precision |           |          | 
+#  hostgal_snsep        | double precision |           |          | 
+#  hostgal_magerr_u     | double precision |           |          | 
+#  hostgal_magerr_g     | double precision |           |          | 
+#  hostgal_magerr_r     | double precision |           |          | 
+#  hostgal_magerr_i     | double precision |           |          | 
+#  hostgal_magerr_z     | double precision |           |          | 
+#  hostgal_magerr_Y     | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_ellipticity | double precision |           |          | 
+#  hostgal2_sqradius    | double precision |           |          | 
+#  hostgal2_zphot       | double precision |           |          | 
+#  hostgal2_zphot_err   | double precision |           |          | 
+#  hostgal2_zphot_q010  | double precision |           |          | 
+#  hostgal2_zphot_q020  | double precision |           |          | 
+#  hostgal2_zphot_q030  | double precision |           |          | 
+#  hostgal2_zphot_q040  | double precision |           |          | 
+#  hostgal2_zphot_q050  | double precision |           |          | 
+#  hostgal2_zphot_q060  | double precision |           |          | 
+#  hostgal2_zphot_q070  | double precision |           |          | 
+#  hostgal2_zphot_q080  | double precision |           |          | 
+#  hostgal2_zphot_q090  | double precision |           |          | 
+#  hostgal2_zphot_q100  | double precision |           |          | 
+#  hostgal2_mag_u       | double precision |           |          | 
+#  hostgal2_mag_g       | double precision |           |          | 
+#  hostgal2_mag_r       | double precision |           |          | 
+#  hostgal2_mag_i       | double precision |           |          | 
+#  hostgal2_mag_z       | double precision |           |          | 
+#  hostgal2_mag_Y       | double precision |           |          | 
+#  hostgal2_ra          | double precision |           |          | 
+#  hostgal2_dec         | double precision |           |          | 
+#  hostgal2_snsep       | double precision |           |          | 
+#  hostgal2_magerr_u    | double precision |           |          | 
+#  hostgal2_magerr_g    | double precision |           |          | 
+#  hostgal2_magerr_r    | double precision |           |          | 
+#  hostgal2_magerr_i    | double precision |           |          | 
+#  hostgal2_magerr_z    | double precision |           |          | 
+#  hostgal2_magerr_Y    | double precision |           |          | 
+#  simVersion           | text             |           |          | 
+#  hostgal2_zphot_q000  | double precision |           |          | 
+#  hostgal2_zspec       | double precision |           |          | 
+#  hostgal2_zspec_err   | double precision |           |          | 
+#  hostgal_zphot        | double precision |           |          | 
+#  hostgal_zphot_err    | double precision |           |          | 
+#  hostgal_zphot_p50    | double precision |           |          | 
+#  hostgal_zphot_q000   | double precision |           |          | 
+#  hostgal2_zphot_p50   | double precision |           |          | 
+# Indexes:
+#     "elasticc_diaobject_pkey" PRIMARY KEY, btree ("diaObjectId")
+#     "idx_elasticc_diaobject_q3c" btree (q3c_ang2ipix(ra, decl))
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaObject_id_809a8089_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaforcedsource" CONSTRAINT "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaobjecttruth" CONSTRAINT "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diasource" CONSTRAINT "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                    Table "public.elasticc_diasource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaSourceId       | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  parentDiaSourceId | bigint           |           |          | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  ra                | double precision |           | not null | 
+#  decl              | double precision |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  snr               | double precision |           | not null | 
+#  nobs              | double precision |           |          | 
+#  diaObject_id      | bigint           |           |          | 
+# Indexes:
+#     "elasticc_diasource_pkey" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diasource_diaObject_id_3b88bc59" btree ("diaObject_id")
+#     "elasticc_diasource_midPointTai_5766b47f" btree ("midPointTai")
+#     "idx_elasticc_diasource_q3c" btree (q3c_ang2ipix(ra, decl))
+# Foreign-key constraints:
+#     "elasticc_diasource_diaObject_id_3b88bc59_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalert" CONSTRAINT "elasticc_diaalert_diaSource_id_1f178060_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+#     TABLE "elasticc_diaalertprvsource" CONSTRAINT "elasticc_diaalertprv_diaSource_id_91fa84a3_fk_elasticc_" FOREIGN KEY ("diaSource_id") REFERENCES elasticc_diasource("diaSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                 Table "public.elasticc_diaforcedsource"
+#       Column       |       Type       | Collation | Nullable | Default 
+# -------------------+------------------+-----------+----------+---------
+#  diaForcedSourceId | bigint           |           | not null | 
+#  ccdVisitId        | bigint           |           | not null | 
+#  midPointTai       | double precision |           | not null | 
+#  filterName        | text             |           | not null | 
+#  psFlux            | double precision |           | not null | 
+#  psFluxErr         | double precision |           | not null | 
+#  totFlux           | double precision |           | not null | 
+#  totFluxErr        | double precision |           | not null | 
+#  diaObject_id      | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaforcedsource_pkey" PRIMARY KEY, btree ("diaForcedSourceId")
+#     "elasticc_diaforcedsource_diaObject_id_8b1bc498" btree ("diaObject_id")
+#     "elasticc_diaforcedsource_midPointTai_a80b03af" btree ("midPointTai")
+# Foreign-key constraints:
+#     "elasticc_diaforcedso_diaObject_id_8b1bc498_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# Referenced by:
+#     TABLE "elasticc_diaalertprvforcedsource" CONSTRAINT "elasticc_diaalertprv_diaForcedSource_id_783ade34_fk_elasticc_" FOREIGN KEY ("diaForcedSource_id") REFERENCES elasticc_diaforcedsource("diaForcedSourceId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                  Table "public.elasticc_diatruth"
+#     Column    |       Type       | Collation | Nullable | Default 
+# --------------+------------------+-----------+----------+---------
+#  diaSourceId  | bigint           |           | not null | 
+#  diaObjectId  | bigint           |           |          | 
+#  detect       | boolean          |           |          | 
+#  true_gentype | integer          |           |          | 
+#  true_genmag  | double precision |           |          | 
+#  mjd          | double precision |           |          | 
+# Indexes:
+#     "elasticc_diatruth_diaSourceId_648273bb_pk" PRIMARY KEY, btree ("diaSourceId")
+#     "elasticc_diatruth_diaObjectId_7dd96889" btree ("diaObjectId")
+#     "elasticc_diatruth_diaSourceId_648273bb_uniq" UNIQUE CONSTRAINT, btree ("diaSourceId")
+# 
+#                  Table "public.elasticc_diaobjecttruth"
+#        Column       |       Type       | Collation | Nullable | Default 
+# --------------------+------------------+-----------+----------+---------
+#  libid              | integer          |           | not null | 
+#  sim_searcheff_mask | integer          |           | not null | 
+#  gentype            | integer          |           | not null | 
+#  sim_template_index | integer          |           | not null | 
+#  zcmb               | double precision |           | not null | 
+#  zhelio             | double precision |           | not null | 
+#  zcmb_smear         | double precision |           | not null | 
+#  ra                 | double precision |           | not null | 
+#  dec                | double precision |           | not null | 
+#  mwebv              | double precision |           | not null | 
+#  galid              | bigint           |           | not null | 
+#  galzphot           | double precision |           | not null | 
+#  galzphoterr        | double precision |           | not null | 
+#  galsnsep           | double precision |           | not null | 
+#  galsnddlr          | double precision |           | not null | 
+#  rv                 | double precision |           | not null | 
+#  av                 | double precision |           | not null | 
+#  mu                 | double precision |           | not null | 
+#  lensdmu            | double precision |           | not null | 
+#  peakmjd            | double precision |           | not null | 
+#  mjd_detect_first   | double precision |           | not null | 
+#  mjd_detect_last    | double precision |           | not null | 
+#  dtseason_peak      | double precision |           | not null | 
+#  peakmag_u          | double precision |           | not null | 
+#  peakmag_g          | double precision |           | not null | 
+#  peakmag_r          | double precision |           | not null | 
+#  peakmag_i          | double precision |           | not null | 
+#  peakmag_z          | double precision |           | not null | 
+#  peakmag_Y          | double precision |           | not null | 
+#  snrmax             | double precision |           | not null | 
+#  snrmax2            | double precision |           | not null | 
+#  snrmax3            | double precision |           | not null | 
+#  nobs               | integer          |           | not null | 
+#  nobs_saturate      | integer          |           | not null | 
+#  diaObject_id       | bigint           |           | not null | 
+# Indexes:
+#     "elasticc_diaobjecttruth_pkey" PRIMARY KEY, btree ("diaObject_id")
+#     "elasticc_diaobjecttruth_gentype_480cd308" btree (gentype)
+#     "elasticc_diaobjecttruth_sim_template_index_b33f9ab4" btree (sim_template_index)
+# Foreign-key constraints:
+#     "elasticc_diaobjecttr_diaObject_id_b5103ef2_fk_elasticc_" FOREIGN KEY ("diaObject_id") REFERENCES elasticc_diaobject("diaObjectId") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                 Table "public.elasticc_classificationmap"
+#     Column     |  Type   | Collation | Nullable |                        Default                         
+# ---------------+---------+-----------+----------+--------------------------------------------------------
+#  id            | integer |           | not null | nextval('elasticc_classificationmap_id_seq'::regclass)
+#  classId       | integer |           | not null | 
+#  snana_gentype | integer |           |          | 
+#  description   | text    |           | not null | 
+# Indexes:
+#     "elasticc_classificationmap_pkey" PRIMARY KEY, btree (id)
+#     "elasticc_classificationmap_classId_27acf0d1" btree ("classId")
+#     "elasticc_classificationmap_snana_gentype_63c19152" btree (snana_gentype)
+# 
+# tom_desc=# \d elasticc_brokermessage
+#                                                      Table "public.elasticc_brokermessage"
+#           Column          |           Type           | Collation | Nullable |                             Default                              
+# --------------------------+--------------------------+-----------+----------+------------------------------------------------------------------
+#  dbMessageIndex           | bigint                   |           | not null | nextval('"elasticc_brokermessage_dbMessageIndex_seq"'::regclass)
+#  streamMessageId          | bigint                   |           |          | 
+#  topicName                | character varying(200)   |           |          | 
+#  alertId                  | bigint                   |           | not null | 
+#  diaSourceId              | bigint                   |           | not null | 
+#  descIngestTimestamp      | timestamp with time zone |           | not null | 
+#  elasticcPublishTimestamp | timestamp with time zone |           |          | 
+#  brokerIngestTimestamp    | timestamp with time zone |           |          | 
+#  modified                 | timestamp with time zone |           | not null | 
+#  msgHdrTimestamp          | timestamp with time zone |           |          | 
+# Indexes:
+#     "elasticc_brokermessage_pkey" PRIMARY KEY, btree ("dbMessageIndex")
+#     "elasticc_br_alertId_b419c9_idx" btree ("alertId")
+#     "elasticc_br_dbMessa_59550d_idx" btree ("dbMessageIndex")
+#     "elasticc_br_diaSour_ca3044_idx" btree ("diaSourceId")
+#     "elasticc_br_topicNa_73f5a4_idx" btree ("topicName", "streamMessageId")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+#                                                    Table "public.elasticc_brokerclassifier"
+#       Column       |           Type           | Collation | Nullable |                                Default                                 
+# -------------------+--------------------------+-----------+----------+------------------------------------------------------------------------
+#  dbClassifierIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassifier_dbClassifierIndex_seq"'::regclass)
+#  brokerName        | character varying(100)   |           | not null | 
+#  brokerVersion     | text                     |           |          | 
+#  classifierName    | character varying(200)   |           | not null | 
+#  classifierParams  | text                     |           |          | 
+#  modified          | timestamp with time zone |           | not null | 
+# Indexes:
+#     "elasticc_brokerclassifier_pkey" PRIMARY KEY, btree ("dbClassifierIndex")
+#     "elasticc_br_brokerN_38d99f_idx" btree ("brokerName", "classifierName")
+#     "elasticc_br_brokerN_86cc1a_idx" btree ("brokerName")
+#     "elasticc_br_brokerN_eb7553_idx" btree ("brokerName", "brokerVersion")
+# Referenced by:
+#     TABLE "elasticc_brokerclassification" CONSTRAINT "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+# 
+# 
+#                                                        Table "public.elasticc_brokerclassification"
+#         Column         |           Type           | Collation | Nullable |                                    Default                                     
+# -----------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------------
+#  dbClassificationIndex | bigint                   |           | not null | nextval('"elasticc_brokerclassification_dbClassificationIndex_seq"'::regclass)
+#  classId               | integer                  |           | not null | 
+#  probability           | double precision         |           | not null | 
+#  modified              | timestamp with time zone |           | not null | 
+#  dbClassifier_id       | bigint                   |           |          | 
+#  dbMessage_id          | bigint                   |           |          | 
+# Indexes:
+#     "elasticc_brokerclassification_pkey" PRIMARY KEY, btree ("dbClassificationIndex")
+#     "elasticc_brokerclassification_dbClassifier_id_91d33318" btree ("dbClassifier_id")
+#     "elasticc_brokerclassification_dbMessage_id_b8bd04da" btree ("dbMessage_id")
+# Foreign-key constraints:
+#     "elasticc_brokerclass_dbClassifier_id_91d33318_fk_elasticc_" FOREIGN KEY ("dbClassifier_id") REFERENCES elasticc_brokerclassifier("dbClassifierIndex") DEFERRABLE INITIALLY DEFERRED
+#     "elasticc_brokerclass_dbMessage_id_b8bd04da_fk_elasticc_" FOREIGN KEY ("dbMessage_id") REFERENCES elasticc_brokermessage("dbMessageIndex") DEFERRABLE INITIALLY DEFERRED


### PR DESCRIPTION
# Caution:  Product of the DESC meeting Sprint day

See `README_kostya.md` for details

## example matrices for alerts
[AMPEL Parsnip.pdf](https://github.com/LSSTDESC/tom_desc/files/9272817/AMPEL.Parsnip.pdf)
[AMPEL SNguess.pdf](https://github.com/LSSTDESC/tom_desc/files/9272818/AMPEL.SNguess.pdf)
[AMPEL SNguessParsnip.pdf](https://github.com/LSSTDESC/tom_desc/files/9272819/AMPEL.SNguessParsnip.pdf)
[ANTARES astrorapid.pdf](https://github.com/LSSTDESC/tom_desc/files/9272820/ANTARES.astrorapid.pdf)
[ANTARES LightGBM_test.pdf](https://github.com/LSSTDESC/tom_desc/files/9272821/ANTARES.LightGBM_test.pdf)

## example matrices for objects
[AMPEL Parsnip.pdf](https://github.com/LSSTDESC/tom_desc/files/9272822/AMPEL.Parsnip.pdf)
[AMPEL SNguess.pdf](https://github.com/LSSTDESC/tom_desc/files/9272823/AMPEL.SNguess.pdf)
[AMPEL SNguessParsnip.pdf](https://github.com/LSSTDESC/tom_desc/files/9272824/AMPEL.SNguessParsnip.pdf)
[ANTARES astrorapid.pdf](https://github.com/LSSTDESC/tom_desc/files/9272825/ANTARES.astrorapid.pdf)
[ANTARES LightGBM_test.pdf](https://github.com/LSSTDESC/tom_desc/files/9272826/ANTARES.LightGBM_test.pdf)

## example output for efficiency

```
AMPEL Parsnip 111 0.03568071326824261
AMPEL Parsnip 112 0.04599349252743617
AMPEL Parsnip 113 0.03675120859494292
AMPEL Parsnip 114 0.031223628691983123
AMPEL Parsnip 115 0.03052866716306776
AMPEL Parsnip 121 0.0
AMPEL Parsnip 122 0.0
AMPEL Parsnip 123 0.020833333333333332
AMPEL Parsnip 124 0.0
AMPEL Parsnip 131 0.14281617436191568
AMPEL Parsnip 132 0.0641025641025641
AMPEL Parsnip 133 0.16216216216216217
AMPEL Parsnip 134 0.039779005524861875
AMPEL Parsnip 135 0.25
AMPEL Parsnip 211 0.0
AMPEL Parsnip 212 0.0
AMPEL Parsnip 213 0.0
AMPEL Parsnip 214 0.0
AMPEL Parsnip 221 0.0
AMPEL SNguess 111 0.0030103979838407373
AMPEL SNguess 112 0.004163679479402195
AMPEL SNguess 113 0.0029215750045477346
AMPEL SNguess 114 0.004430379746835443
AMPEL SNguess 115 0.003226607098535617
AMPEL SNguess 121 0.0
AMPEL SNguess 122 0.0
AMPEL SNguess 123 0.004166666666666667
AMPEL SNguess 124 0.0
AMPEL SNguess 131 0.015199311729280183
AMPEL SNguess 132 0.007692307692307693
AMPEL SNguess 133 0.018018018018018018
AMPEL SNguess 134 0.0033149171270718232
AMPEL SNguess 135 0.05
AMPEL SNguess 211 0.0
AMPEL SNguess 212 0.0
AMPEL SNguess 213 0.0
AMPEL SNguess 214 0.0
AMPEL SNguess 221 0.0
AMPEL SNguessParsnip 111 0.022312700765286998
AMPEL SNguessParsnip 112 0.025892020073898417
AMPEL SNguessParsnip 113 0.02053371111686851
AMPEL SNguessParsnip 114 0.0189873417721519
AMPEL SNguessParsnip 115 0.020352444775378505
AMPEL SNguessParsnip 121 0.0
AMPEL SNguessParsnip 122 0.0
AMPEL SNguessParsnip 123 0.0125
AMPEL SNguessParsnip 124 0.0
AMPEL SNguessParsnip 131 0.06452537998279323
AMPEL SNguessParsnip 132 0.035256410256410256
AMPEL SNguessParsnip 133 0.0990990990990991
AMPEL SNguessParsnip 134 0.026519337016574586
AMPEL SNguessParsnip 135 0.15
AMPEL SNguessParsnip 211 0.0
AMPEL SNguessParsnip 212 0.0
AMPEL SNguessParsnip 213 0.0
AMPEL SNguessParsnip 214 0.0
AMPEL SNguessParsnip 221 0.0
ANTARES LightGBM_test 111 0.11798222596439426
ANTARES LightGBM_test 112 0.12005735399547786
ANTARES LightGBM_test 113 0.11506595593382908
ANTARES LightGBM_test 114 0.1189873417721519
ANTARES LightGBM_test 115 0.0
ANTARES LightGBM_test 121 0.0
ANTARES LightGBM_test 122 0.11651917404129794
ANTARES LightGBM_test 123 0.15833333333333333
ANTARES LightGBM_test 124 0.20441988950276244
ANTARES LightGBM_test 131 0.13593346716375107
ANTARES LightGBM_test 132 0.13974358974358975
ANTARES LightGBM_test 133 0.17117117117117117
ANTARES LightGBM_test 134 0.10718232044198896
ANTARES LightGBM_test 135 0.1
ANTARES LightGBM_test 211 0.8504672897196262
ANTARES LightGBM_test 212 0.7366825465569511
ANTARES LightGBM_test 213 0.7316239316239316
ANTARES LightGBM_test 214 0.5949367088607594
ANTARES LightGBM_test 221 0.241243961352657
ANTARES astrorapid 111 0.0039273582892634905
ANTARES astrorapid 112 0.0052390668946120334
ANTARES astrorapid 113 0.0018797303331146745
ANTARES astrorapid 114 0.0
ANTARES astrorapid 115 0.0047158103747828245
ANTARES astrorapid 121 0.0
ANTARES astrorapid 122 0.0
ANTARES astrorapid 123 0.0
ANTARES astrorapid 124 0.06629834254143646
ANTARES astrorapid 131 0.0
ANTARES astrorapid 132 0.007692307692307693
ANTARES astrorapid 133 0.018018018018018018
ANTARES astrorapid 134 0.0
ANTARES astrorapid 135 0.1
ANTARES astrorapid 211 0.308411214953271
ANTARES astrorapid 212 0.034430489389346036
ANTARES astrorapid 213 0.005128205128205128
ANTARES astrorapid 214 0.010516066212268744
ANTARES astrorapid 221 0.003472222222222222
```
