### PR TITLE
Add PittGoogleBroker

### DIFF
--- a/tom_desc/elasticc2/management/commands/brokerpoll2.py
+++ b/tom_desc/elasticc2/management/commands/brokerpoll2.py
@@ -319,9 +319,8 @@ class PittGoogleBroker(BrokerConsumer):
         batch_maxn: int = 1000,  # max number of messages in a batch
         batch_maxwait: int = 5,  # max seconds to wait between messages before processing a batch
         loggername: str = "PITTGOOGLE",
-        schemafile: pathlib.Path = None,
     ):
-        logger = logging.getLogger(loggername)
+        super().__init__(server=None, groupid=None, loggername=loggername)
 
         if schemafile is None:
             schemafile = _rundir / "elasticc.v0_9_1.brokerClassification.avsc"
@@ -339,9 +338,9 @@ class PittGoogleBroker(BrokerConsumer):
                 max_workers=max_workers,
                 initializer=self.worker_init,
                 initargs=(
-                    fastavro.schema.load_schema(schemafile),
+                    self.schema,
                     subscription.topic.name,
-                    logger,
+                    self.logger,
                 ),
             ),
         )

--- a/tom_desc/elasticc2/management/commands/brokerpoll2.py
+++ b/tom_desc/elasticc2/management/commands/brokerpoll2.py
@@ -11,6 +11,8 @@ import json
 import multiprocessing
 import fastavro
 import confluent_kafka
+import pittgoogle
+from concurrent.futures import ThreadPoolExecutor
 from django.core.management.base import BaseCommand, CommandError
 from elasticc2.models import BrokerMessage
 
@@ -306,6 +308,88 @@ class AlerceConsumer(BrokerConsumer):
                 tosub.append( topic )
         self.topics = tosub
         self.consumer.subscribe( self.topics )
+
+# =====================================================================
+
+class PittGoogleBroker(BrokerConsumer):
+    def __init__(
+        self,
+        subscription_name: str,
+        max_workers: int = 8,  # max number of ThreadPoolExecutor threads
+        batch_maxn: int = 1000,  # max number of messages in a batch
+        batch_maxwait: int = 5,  # max seconds to wait between messages before processing a batch
+        loggername: str = "PITTGOOGLE",
+        schemafile: pathlib.Path = None,
+    ):
+        logger = logging.getLogger(loggername)
+
+        if schemafile is None:
+            schemafile = _rundir / "elasticc.v0_9_1.brokerClassification.avsc"
+
+        subscription = pittgoogle.pubsub.Subscription(name=subscription_name)
+        subscription.touch()
+
+        self.consumer = pittgoogle.pubsub.Consumer(
+            subscription=subscription,
+            msg_callback=self.handle_message,
+            batch_callback=self.handle_message_batch,
+            batch_maxn=batch_maxn,
+            batch_maxwait=batch_maxwait,
+            executor=ThreadPoolExecutor(
+                max_workers=max_workers,
+                initializer=self.worker_init,
+                initargs=(
+                    fastavro.schema.load_schema(schemafile),
+                    subscription.topic.name,
+                    logger,
+                ),
+            ),
+        )
+
+    @staticmethod
+    def worker_init(classification_schema: dict, pubsub_topic: str, broker_logger: logging.Logger):
+        global logger
+        global schema
+        global topic
+
+        logger = broker_logger
+        schema = classification_schema
+        topic = pubsub_topic
+
+    @staticmethod
+    def handle_message(alert: pittgoogle.pubsub.Alert) -> pittgoogle.pubsub.Response:
+        global schema
+        global topic
+
+        message = {
+            "msg": fastavro.schemaless_reader(io.BytesIO(alert.bytes), schema),
+            "topic": topic,
+            # this is a DatetimeWithNanoseconds, a subclass of datetime.datetime
+            # https://googleapis.dev/python/google-api-core/latest/helpers.html
+            "timestamp": alert.metadata["publish_time"].astimezone(datetime.timezone.utc),
+            # there is no offset in pubsub
+            # if this cannot be null, perhaps the message id would work?
+            "msgoffset": alert.metadata["message_id"],
+        }
+
+        return pittgoogle.pubsub.Response(result=message, ack=True)
+
+    @staticmethod
+    def handle_message_batch(messagebatch: list) -> None:
+        global logger
+
+        added = BrokerMessage.load_batch(messagebatch, logger=logger)
+        logger.info(
+            f"...added {added['addedmsgs']} messages, "
+            f"{added['addedclassifiers']} classifiers, "
+            f"{added['addedclassifications']} classifications. "
+        )
+
+    def poll(self):
+        # this blocks indefinitely or until a fatal error
+        # use Control-C to exit
+        self.consumer.stream()
+
 
 # =====================================================================
 # To make this die cleanly, send the USR1 signal to it

--- a/tom_desc/elasticc2/management/commands/brokerpoll2.py
+++ b/tom_desc/elasticc2/management/commands/brokerpoll2.py
@@ -314,18 +314,19 @@ class AlerceConsumer(BrokerConsumer):
 class PittGoogleBroker(BrokerConsumer):
     def __init__(
         self,
-        subscription_name: str,
-        max_workers: int = 8,  # max number of ThreadPoolExecutor threads
+        topic_name: str,
+        topic_project: str,
+        max_workers: int = 8,  # max number of ThreadPoolExecutor workers
         batch_maxn: int = 1000,  # max number of messages in a batch
         batch_maxwait: int = 5,  # max seconds to wait between messages before processing a batch
         loggername: str = "PITTGOOGLE",
     ):
         super().__init__(server=None, groupid=None, loggername=loggername)
 
-        if schemafile is None:
-            schemafile = _rundir / "elasticc.v0_9_1.brokerClassification.avsc"
-
-        subscription = pittgoogle.pubsub.Subscription(name=subscription_name)
+        topic = pittgoogle.pubsub.Topic(topic_name, topic_project)
+        subscription = pittgoogle.pubsub.Subscription(name=f"{topic_name}-desc", topic=topic)
+        # if the subscription doesn't already exist, this will create one in the
+        # project given by the env var GOOGLE_CLOUD_PROJECT
         subscription.touch()
 
         self.consumer = pittgoogle.pubsub.Consumer(

--- a/tom_desc/elasticc2/management/commands/brokerpoll2.py
+++ b/tom_desc/elasticc2/management/commands/brokerpoll2.py
@@ -12,7 +12,7 @@ import multiprocessing
 import fastavro
 import confluent_kafka
 import pittgoogle
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor  # for pittgoogle
 from django.core.management.base import BaseCommand, CommandError
 from elasticc2.models import BrokerMessage
 
@@ -348,6 +348,7 @@ class PittGoogleBroker(BrokerConsumer):
 
     @staticmethod
     def worker_init(classification_schema: dict, pubsub_topic: str, broker_logger: logging.Logger):
+        """Initializer for the ThreadPoolExecutor."""
         global logger
         global schema
         global topic
@@ -358,6 +359,7 @@ class PittGoogleBroker(BrokerConsumer):
 
     @staticmethod
     def handle_message(alert: pittgoogle.pubsub.Alert) -> pittgoogle.pubsub.Response:
+        """Callback that will process a single message. This will run in a background thread."""
         global schema
         global topic
 
@@ -376,6 +378,7 @@ class PittGoogleBroker(BrokerConsumer):
 
     @staticmethod
     def handle_message_batch(messagebatch: list) -> None:
+        """Callback that will process a batch of messages. This will run in the main thread."""
         global logger
 
         added = BrokerMessage.load_batch(messagebatch, logger=logger)


### PR DESCRIPTION
Add support for Pitt-Google classification streams -- add class:  `PittGoogleBroker`. 

## Prerequisites

- `pip install pittgoogle-client>=0.2.0`
- Download a credentials key file and set environment variables. Instructions are in our docs ([Authentication: Service Account](https://mwvgroup.github.io/pittgoogle-client/overview/authentication.html#service-account-recommended)), but see the TLDR in the comment below.

## Code Details

On the surface, the workflow is very similar to the other `BrokerConsumer` classes:  connect to the stream, pull batches of messages, load the batches using `BrokerMessage.load_batch`. Under the hood, there are several differences, outlined below.

This connects to a Pitt-Google message stream by calling the `pittgoogle` API ([pittgoogle docs](https://mwvgroup.github.io/pittgoogle-client)), which in turn calls Google's API `google.cloud.pubsub_v1`. Google's streaming pull operates in the background using a `concurrent.futures.ThreadPoolExecutor`. 

Google imposes a workflow where each message is processed and acknowledged independently. `pittgoogle` adds the ability to collect and process a batch of results. Thus, there are two callbacks:  one for a single message and the other for a batch. The messages are delete from the subscription after a successful message callback but before the batch callback runs. Thus, the message callback should do as much of the required processing as possible.

Once the streaming pull has begun it will run indefinitely, until it encounters a fatal error. Typically, one uses `Ctrl-C` to stop it, but I see that may not work for you here. We can discuss a better way to stop.

## Next Steps

I've tested most everything I can short of running a tom_desc container. Please follow the prerequisites above, then try this out within your system. A basic example looks like this:

```python
import pittgoogle
from brokerpoll2 import PittGoogleBroker  # tom_desc/elasticc2/management/commands/brokerpoll2.py


broker = PittGoogleBroker(
    topic_name="classifications-loop",  # heartbeat topic with dummy data, for testing
    topic_project=pittgoogle.utils.ProjectIds.pittgoogle_dev,
    max_workers=8,  # max number of ThreadPoolExecutor workers
    batch_maxn=1000,  # max number of messages in a batch
    batch_maxwait=5,  # max seconds to wait between messages before processing a batch
)

broker.poll(). # runs indefinitely. use `Ctrl-C` to stop.
```

I have not added `PittGoogleBroker` to whatever initializer launches the broker consumers (class `Command`?).